### PR TITLE
make Tiddlywiki work after running build.sh seamlesly

### DIFF
--- a/plugins/datepicker/build.sh
+++ b/plugins/datepicker/build.sh
@@ -20,7 +20,7 @@ targetjs="pikaday.js"                      # target javascript file name
 printf "Fetch upstream resources...\n"
 #====================================================================
 
-git submodule update --recursive --remote
+git submodule update --init --recursive --remote
 
 #====================================================================
 printf "Perform cleanup...\n"

--- a/plugins/datepicker/tiddlywiki.files
+++ b/plugins/datepicker/tiddlywiki.files
@@ -1,0 +1,32 @@
+{
+  "tiddlers": [
+    {
+      "file": "media/icon.tid",
+      "isTiddlerFile": "true"
+    },
+    {
+      "file": "tiddlers/license.tid",
+	  "isTiddlerFile": "true"
+    },
+    {
+      "file": "tiddlers/pikaday.css.tid",
+	  "isTiddlerFile": "true"
+    },
+    {
+      "file": "pikaday.js",
+	  "isTiddlerFile": "true"
+    },
+    {
+      "file": "tiddlers/readme.tid",
+	  "isTiddlerFile": "true"
+    },
+    {
+      "file": "tiddlers/usage.tid",
+	  "isTiddlerFile": "true"
+    },
+    {
+      "file": "widget.datepicker.js",
+	  "isTiddlerFile": "true"
+    }
+  ]
+}


### PR DESCRIPTION
Hi,

i cloned your repo, ran build.sh and afterwards tried to run the plugin directly - with the outcome that several additional files out of the intermediate "temp"-folder and the "Pikaday"-Folder where added to my TW-instance. From my opinion it is to be preferred to have a tiddlywiki.file in place.

Regards,
Mirko