### PR TITLE
fix: use standard field name

### DIFF
--- a/plugins/datepicker/plugin.info
+++ b/plugins/datepicker/plugin.info
@@ -6,6 +6,6 @@
   "core-version": ">=5.1.8",
   "source": "https://github.com/kixam/TW5-datepicker.js",
   "list": "readme license usage",
-  "depends": ["$:/plugins/kixam/moment"],
+  "dependents": ["$:/plugins/kixam/moment"],
   "plugin-type": "plugin"
 }


### PR DESCRIPTION
Otherwise it can't be auto install by any plugin library.